### PR TITLE
Transfer double buffer into Cell instances

### DIFF
--- a/src/GOL/Cell.js
+++ b/src/GOL/Cell.js
@@ -14,6 +14,7 @@ dark matte pink: #b74366, a83c5e
 class Cell {
 
   constructor(p, i, j){
+    this.prevActive = false;
     this.active = false;
     this.id = null;
     this.x = i;
@@ -26,6 +27,14 @@ class Cell {
     this.generation = 0;
     this.centaFill = "#F1FFC0";
     this.hoverFill = "#363636";
+  }
+
+  getPrevActivity = () => {
+    return this.prevActive;
+  }
+
+  setPrevActivityToActive = () => {
+    this.prevActive = this.active;
   }
 
   getActivity = () => {

--- a/src/GOL/GridSketch.js
+++ b/src/GOL/GridSketch.js
@@ -18,7 +18,7 @@ function sketch (p){
   const rows = GridConstants.num_rows;
   let parentW = document.querySelector(".sketch-container").clientWidth;
   let parentH = document.querySelector(".sketch-container").clientHeight;
-  let currGrid = [[]], nextGrid = [[]]
+  let currGrid = [[]];
   let cellFill = "#cc527a", textFill = "#D11554", textStroke="#e8175d";
   // textStroke2 = rgba(232, 23, 93, 0.4);
   let isBlasting = false, goForClear = 0;
@@ -33,7 +33,6 @@ function sketch (p){
           currGrid[i][j] = new Cell(p, i, j, cellFill);
         }
     }
-    nextGrid = currGrid;
   };
 
   const stirChaos = () => {
@@ -84,6 +83,7 @@ function sketch (p){
     for(let i=0; i<cols; i++){
       for(let j=0; j<rows; j++){
         currGrid[i][j].setGeneration(generations);
+        currGrid[i][j].setPrevActivityToActive();
         currGrid[i][j].createRect();
 
       }
@@ -129,37 +129,32 @@ function sketch (p){
     for(let i=1; i<cols-1; i++){
       for( let j=1; j<rows-1; j++){
         let theLoving = 0;
-        if(currGrid[i-1][j-1].getActivity() == true){theLoving++;}
-        if(currGrid[i-1][j+1].getActivity() == true){theLoving++;}
-        if(currGrid[i-1][j].getActivity() == true){theLoving++;}
-        if(currGrid[i+1][j-1].getActivity() == true){theLoving++;}
-        if(currGrid[i+1][j].getActivity() == true){theLoving++;}
-        if(currGrid[i+1][j+1].getActivity() == true){theLoving++;}
-        if(currGrid[i][j-1].getActivity() == true){theLoving++;}
-        if(currGrid[i][j+1].getActivity() == true){theLoving++;}
+        if(currGrid[i-1][j-1].getPrevActivity() === true){theLoving++;}
+        if(currGrid[i-1][j+1].getPrevActivity() === true){theLoving++;}
+        if(currGrid[i-1][j  ].getPrevActivity() === true){theLoving++;}
+        if(currGrid[i+1][j-1].getPrevActivity() === true){theLoving++;}
+        if(currGrid[i+1][j  ].getPrevActivity() === true){theLoving++;}
+        if(currGrid[i+1][j+1].getPrevActivity() === true){theLoving++;}
+        if(currGrid[i  ][j-1].getPrevActivity() === true){theLoving++;}
+        if(currGrid[i  ][j+1].getPrevActivity() === true){theLoving++;}
+
+
         if(theLoving > 3 || theLoving < 2){
           if(currGrid[i][j].getActivity() == true){
-            nextGrid[i][j].setActiveToFalse();
+            currGrid[i][j].setActiveToFalse();
           }
         } else if (theLoving == 3) {
           if(currGrid[i][j].getActivity() == false){
-            nextGrid[i][j].setActiveToTrue();
+            currGrid[i][j].setActiveToTrue();
           }
         } else {
-          nextGrid[i][j].setActivity(currGrid[i][j].getActivity());
+          currGrid[i][j].setActivity(currGrid[i][j].getActivity());
         }
       }
     }
 
-    swapJudgement();
     incrementGenerations();
   };
-
-  const swapJudgement = () => {
-    let temp = currGrid;
-    currGrid = nextGrid;
-    nextGrid = temp;
-  }
 
   const incrementGenerations = () => {
     generations += 1;


### PR DESCRIPTION
Two arrays were used to double buffer. This is so that judgment (_calculation_) was done on a consistent state by reading from one array and writing to another. The problem is that the elements of the arrays were objects (Cell instances). Because objects are passed by reference in JS, both arrays essentially point to the same Cells. Thus, changing the cell in one array changes the cell in another array, since they are the same cell in both arrays, leading to inconsistent state during judgment.

This is addressed by removing the double array buffer system and instead having each Cell instance track its current and previous state. Calculation would be done based on the cell's previous state, and the result will be set to the cell's current state. After calculations on _all_ cells are done, the cell's current state is copied to the previous state during drawing.